### PR TITLE
[TAMU Sprint 7 78] Expose findByName endpoint for DisplayView

### DIFF
--- a/src/main/java/edu/tamu/scholars/middleware/config/WebSecurityConfig.java
+++ b/src/main/java/edu/tamu/scholars/middleware/config/WebSecurityConfig.java
@@ -183,7 +183,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                         "/themes/search/active",
                         "/directoryViews", "/directoryViews/{id}",
                         "/discoveryViews", "/discoveryViews/{id}",
-                        "/displayViews", "/displayViews/{id}", "/displayViews/search/findByTypesIn",
+                        "/displayViews", "/displayViews/{id}", "/displayViews/search/findByTypesIn", "/displayViews/search/findByName",
                         "/collections", "/collections/{id}", "/collections/search/findByIdIn", "/collections/search/facet", "/collections/search/export", "/collections/search/count", "/collections/search/recently-updated",
                         "/concepts", "/concepts/{id}", "/concepts/search/findByIdIn", "/concepts/search/facet", "/concepts/search/export", "/concepts/search/count", "/concepts/search/recently-updated",
                         "/documents", "/documents/{id}", "/documents/search/findByIdIn", "/documents/search/facet", "/documents/search/export", "/documents/search/count", "/documents/search/recently-updated",

--- a/src/main/java/edu/tamu/scholars/middleware/view/model/repo/DisplayViewRepo.java
+++ b/src/main/java/edu/tamu/scholars/middleware/view/model/repo/DisplayViewRepo.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.annotation.RestResource;
 
 import edu.tamu.scholars.middleware.view.model.DisplayView;
 
@@ -12,4 +13,9 @@ public interface DisplayViewRepo extends ViewRepo<DisplayView> {
 
     public Optional<DisplayView> findByTypesIn(List<String> types);
 
+    public Optional<DisplayView> findByNameIn(List<String> names);
+
+    @Override
+    @RestResource(exported = true)
+    public Optional<DisplayView> findByName(String name);
 }

--- a/src/main/java/edu/tamu/scholars/middleware/view/model/repo/DisplayViewRepo.java
+++ b/src/main/java/edu/tamu/scholars/middleware/view/model/repo/DisplayViewRepo.java
@@ -13,8 +13,6 @@ public interface DisplayViewRepo extends ViewRepo<DisplayView> {
 
     public Optional<DisplayView> findByTypesIn(List<String> types);
 
-    public Optional<DisplayView> findByNameIn(List<String> names);
-
     @Override
     @RestResource(exported = true)
     public Optional<DisplayView> findByName(String name);


### PR DESCRIPTION
The implementations of Issues #78 and #79 are affected by the PR(#85) for issues #75 and #76.

It affects #78 by providing a client side mechanism for aggregating sections.

It affect #79 by utilizing an existing Spring Data API endpoint to retrieve the template metadata, rather than a new embed endpoint.



