### PR TITLE
#184: fix paging for grapqhl interface

### DIFF
--- a/src/main/java/edu/tamu/scholars/middleware/graphql/service/AbstractNestedDocumentService.java
+++ b/src/main/java/edu/tamu/scholars/middleware/graphql/service/AbstractNestedDocumentService.java
@@ -16,7 +16,6 @@ import java.util.stream.StreamSupport;
 
 import javax.annotation.PostConstruct;
 
-import org.docx4j.wml.P;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;

--- a/src/main/java/edu/tamu/scholars/middleware/graphql/service/AbstractNestedDocumentService.java
+++ b/src/main/java/edu/tamu/scholars/middleware/graphql/service/AbstractNestedDocumentService.java
@@ -16,6 +16,7 @@ import java.util.stream.StreamSupport;
 
 import javax.annotation.PostConstruct;
 
+import org.docx4j.wml.P;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -208,8 +209,10 @@ public abstract class AbstractNestedDocumentService<ND extends AbstractNestedDoc
         Map<org.springframework.data.solr.core.query.Field, Page<FacetFieldEntry>> facetFieldResults = new HashMap<org.springframework.data.solr.core.query.Field, Page<FacetFieldEntry>>();
         facetPage.getFacetFields().forEach(field ->  facetFieldResults.put(field, facetPage.getFacetResultPage(field)));
         List<ND> content = facetPage.getContent().stream().map(document -> toNested(document, fields)).collect(Collectors.toList());
-        SolrResultPage<ND> results = new SolrResultPage<ND>(content);
-        results.addAllFacetFieldResultPages(facetFieldResults);
+        
+        Pageable resultsPaging = facetPage.getPageable();
+        SolrResultPage<ND> results = new SolrResultPage<ND>(content, resultsPaging, new Long(facetPage.getTotalElements()), null);
+        results.addAllFacetFieldResultPages(facetFieldResults);        
         return results;
     }
 


### PR DESCRIPTION
This manually adds paging information to created `SolrResultPage` when searching repository from grapqhl service call

I don't have a good feel for whether this is a) a good way to fix the problem b) there are ramifications with making up the `total` parameter and sending in null for `maxScore`.  Would have preferred a `SolrResultPage` constructor that only took `content` and `pageable`

Seemed to work in limited testing with our set of 13 people