### PR TITLE
dont apply score sort automatically

### DIFF
--- a/src/main/java/edu/tamu/scholars/middleware/discovery/DiscoveryConstants.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/DiscoveryConstants.java
@@ -10,8 +10,6 @@ public class DiscoveryConstants {
 
     public static final String CLASS = "class";
 
-    public static final String SCORE = "score";
-
     public static final String MOD_TIME = "modTime";
 
     public static final String DEFAULT_QUERY = String.format("%s:%s", WILDCARD, WILDCARD);

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/Person.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/Person.java
@@ -22,7 +22,7 @@ import io.leangen.graphql.annotations.GraphQLIgnore;
 @CollectionSource(name = "persons", predicate = "http://xmlns.com/foaf/0.1/Person")
 public class Person extends Common {
 
-    @Indexed(type = "sorting_string")
+    @Indexed(type = "sorting_string", copyTo = "_text_")
     @PropertySource(template = "person/name", predicate = "http://www.w3.org/2000/01/rdf-schema#label")
     private String name;
 

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/impl/IndividualRepoImpl.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/impl/IndividualRepoImpl.java
@@ -173,7 +173,7 @@ public class IndividualRepoImpl implements SolrDocumentRepoCustom<Individual> {
     }
 
     private Optional<Criteria> getBoostCriteria(String query, List<BoostArg> boosts) {
-        return query.equals(DEFAULT_QUERY) ? Optional.empty() : boosts.stream().map(boost -> Criteria.where(boost.getProperty()).is(query).boost(boost.getValue())).reduce((c1, c2) -> c1.or(c2));
+        return query.equals(DEFAULT_QUERY) ? Optional.empty() : boosts.stream().map(boost -> Criteria.where(boost.getProperty()).expression(query).boost(boost.getValue())).reduce((c1, c2) -> c1.or(c2));
     }
 
     private SimpleQuery buildSimpleQuery(List<FilterArg> filters) {

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/impl/IndividualRepoImpl.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/impl/IndividualRepoImpl.java
@@ -3,7 +3,6 @@ package edu.tamu.scholars.middleware.discovery.model.repo.impl;
 import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.DEFAULT_QUERY;
 import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.ID;
 import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.MOD_TIME;
-import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.SCORE;
 import static org.springframework.data.solr.core.query.Criteria.WILDCARD;
 
 import java.util.ArrayList;
@@ -17,7 +16,6 @@ import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -117,7 +115,6 @@ public class IndividualRepoImpl implements SolrDocumentRepoCustom<Individual> {
 
         if (boostCriteria.isPresent()) {
             criteria = boostCriteria.get().or(criteria);
-            page = PageRequest.of(page.getPageNumber(), page.getPageSize(), Sort.by(SCORE).descending().and(page.getSort()));
         }
 
         facetQuery.addCriteria(criteria);
@@ -160,7 +157,6 @@ public class IndividualRepoImpl implements SolrDocumentRepoCustom<Individual> {
 
         if (boostCriteria.isPresent()) {
             criteria = boostCriteria.get().or(criteria);
-            sort = Sort.by(SCORE).descending().and(sort);
         }
 
         simpleQuery.addCriteria(criteria);

--- a/src/main/resources/defaults/discoveryViews.yml
+++ b/src/main/resources/defaults/discoveryViews.yml
@@ -72,6 +72,8 @@
     - field: name
       value: 4
   sort:
+    - field: score
+      direction: DESC
     - field: name
       direction: ASC
   export:
@@ -169,6 +171,8 @@
     - field: abstract
       value: 2
   sort:
+    - field: score
+      direction: DESC
     - field: title
       direction: ASC
   export:
@@ -270,6 +274,8 @@
     - field: awardedBy
       value: 2
   sort:
+    - field: score
+      direction: DESC
     - field: title
       direction: ASC
   export:
@@ -336,6 +342,8 @@
     - field: name
       value: 2
   sort:
+    - field: score
+      direction: DESC
     - field: name
       direction: ASC
   export:
@@ -389,6 +397,8 @@
     - field: title
       value: 2
   sort:
+    - field: score
+      direction: DESC
     - field: title
       direction: ASC
   export:
@@ -432,6 +442,8 @@
     - field: name
       value: 2
   sort:
+    - field: score
+      direction: DESC
     - field: name
       direction: ASC
   export:
@@ -479,6 +491,8 @@
     - field: name
       value: 2
   sort:
+    - field: score
+      direction: DESC
     - field: name
       direction: ASC
   export:


### PR DESCRIPTION
This removes the automatic sort by score if boost specified on query and uses expression for boost criteria.