### PR TITLE
#211: add generic facet limit and set to unlimited 

### DIFF
--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/impl/IndividualRepoImpl.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/impl/IndividualRepoImpl.java
@@ -118,7 +118,6 @@ public class IndividualRepoImpl implements SolrDocumentRepoCustom<Individual> {
         }
 
         facetQuery.addCriteria(criteria);
-   
         // NOTE: solr does not return total number of facet entries, nor afford direction of sort
         FacetOptions facetOptions = new FacetOptions();
         facetOptions.setFacetLimit(-1);        

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/impl/IndividualRepoImpl.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/impl/IndividualRepoImpl.java
@@ -118,16 +118,15 @@ public class IndividualRepoImpl implements SolrDocumentRepoCustom<Individual> {
         }
 
         facetQuery.addCriteria(criteria);
-
+   
         // NOTE: solr does not return total number of facet entries, nor afford direction of sort
         FacetOptions facetOptions = new FacetOptions();
+        facetOptions.setFacetLimit(-1);        
 
         facets.forEach(facet -> {
             FieldWithFacetParameters fieldWithFacetParameters = new FieldWithFacetParameters(facet.getCommand());
-            facetOptions.addFacetOnField(fieldWithFacetParameters);
-            fieldWithFacetParameters.setLimit(Integer.MAX_VALUE);
-            fieldWithFacetParameters.setOffset(0);
             // NOTE: other possible; method, minCount, missing, and prefix
+            facetOptions.addFacetOnField(fieldWithFacetParameters);
         });
 
         if (facetOptions.hasFacets()) {


### PR DESCRIPTION
NOTE: field level limits are ignored when exclusionTag is used (from GraphQL endpoint)

The problem is SOLR set limits on facets like `f.<field-name>.facet.limit=#` - but when an exclusionTag is added ("{!ex=tag}") to the field name, the `FieldWithFacetParameter` sends that along as part of the limit command (`f.{!ex%3Dtag}<field-name>.facet.limit=#`)- and SOLR looks to be ignoring it, so it falls back to the higher level default (which is 10).  So the effect is adding an exclusionTag limits facets to 10.

This just sets the limit to unlimited (-1).  I tried Integer.MAX_VALUE, but got JVM Error `Array too big`. This change does still honor "pageSize" as a parameter (so it can be limited that way).  