### PR TITLE
remove java 8 and 10 from ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 
 jdk:
-  - openjdk8
-  - openjdk10
   - openjdk11
 
 install:


### PR DESCRIPTION
still supporting java 8 and 10, but travis ci is not responding with all of them