### PR TITLE
Fixed boosted expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 
 jdk:
-  - openjdk8
-  - openjdk10
   - openjdk11
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 
 jdk:
+  - openjdk8
+  - openjdk10
   - openjdk11
 
 install:

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/DiscoveryConstants.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/DiscoveryConstants.java
@@ -24,8 +24,8 @@ public class DiscoveryConstants {
 
     public static final String PATH_DELIMETER_REGEX = "\\.";
 
-    public static final String EMPTY_STRING = "";
-
     public static final String DISCOVERY_MODEL_PACKAGE = "edu.tamu.scholars.middleware.discovery.model";
+
+    public static final String PARENTHESES_TEMPLATE = "(%s)";
 
 }

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/Person.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/Person.java
@@ -560,15 +560,15 @@ public class Person extends Common {
     @PropertySource(template = "person/email", predicate = "http://www.w3.org/2006/vcard/ns#email")
     private String email;
 
-    @Indexed(type = "whole_string", copyTo = "_text_")
+    @Indexed(type = "tokenized_string")
     @PropertySource(template = "person/firstName", predicate = "http://www.w3.org/2006/vcard/ns#givenName")
     private String firstName;
 
-    @Indexed(type = "whole_string", copyTo = "_text_")
+    @Indexed(type = "tokenized_string")
     @PropertySource(template = "person/middleName", predicate = "http://www.w3.org/2006/vcard/ns#middleName")
     private String middleName;
 
-    @Indexed(type = "whole_string", copyTo = "_text_")
+    @Indexed(type = "tokenized_string")
     @PropertySource(template = "person/lastName", predicate = "http://www.w3.org/2006/vcard/ns#familyName")
     private String lastName;
 

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/impl/IndividualRepoImpl.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/impl/IndividualRepoImpl.java
@@ -1,6 +1,6 @@
 package edu.tamu.scholars.middleware.discovery.model.repo.impl;
 
-import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.CLASS;
+import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.*;
 import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.DEFAULT_QUERY;
 import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.ID;
 import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.MOD_TIME;
@@ -223,7 +223,8 @@ public class IndividualRepoImpl implements SolrDocumentRepoCustom<Individual> {
             return new Criteria(WILDCARD).expression(WILDCARD);
         }
         Criteria criteria = new SimpleStringCriteria(query).connect();
-        boosts.stream().map(boost -> Criteria.where(boost.getField()).expression(query).boost(boost.getValue())).forEach(boostCriteria -> {
+        String expression = String.format(PARENTHESES_TEMPLATE, query);
+        boosts.stream().map(boost -> Criteria.where(boost.getField()).expression(expression).boost(boost.getValue())).forEach(boostCriteria -> {
             criteria.or(boostCriteria.connect());
         });
         return criteria;

--- a/src/main/java/edu/tamu/scholars/middleware/export/service/CsvExporter.java
+++ b/src/main/java/edu/tamu/scholars/middleware/export/service/CsvExporter.java
@@ -1,6 +1,5 @@
 package edu.tamu.scholars.middleware.export.service;
 
-import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.EMPTY_STRING;
 import static edu.tamu.scholars.middleware.discovery.DiscoveryConstants.NESTED_DELIMITER;
 
 import java.io.OutputStreamWriter;
@@ -11,6 +10,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.solr.core.query.result.Cursor;
 import org.springframework.stereotype.Service;
@@ -88,7 +88,7 @@ public class CsvExporter implements Exporter {
                 row.add(String.format("%s/%s", config.getIndividualBaseUri(), document.getId()));
                 continue;
             }
-            String value = EMPTY_STRING;
+            String value = StringUtils.EMPTY;
             if (content.containsKey(property)) {
                 List<String> values = content.get(property);
                 if (values.size() > 0) {


### PR DESCRIPTION
Boosted expressions in query were not being prepared correctly.

was this

`q=robin+young+OR+(firstName:robin+young)^2+OR+(lastName:robin+young)^2`

now this

`q=robin+young+OR+firstName:(robin+young)^2+OR+lastName:(robin+young)^2`

the previous was boosting matches on term `young` in the default search field