### PR TITLE
#219: adds ability to specific facet.mincount as facet arg in GraphQL

### DIFF
--- a/src/main/java/edu/tamu/scholars/middleware/discovery/argument/FacetArg.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/argument/FacetArg.java
@@ -22,13 +22,16 @@ public class FacetArg {
 
     private final String exclusionTag;
 
-    public FacetArg(String field, String sort, int pageSize, int pageNumber, String type, String exclusionTag) {
+    private final int minCount;
+
+    public FacetArg(String field, String sort, int pageSize, int pageNumber, String type, String exclusionTag, int minCount) {
         this.field = DiscoveryUtility.findProperty(field);
         this.sort = FacetSortArg.of(sort);
         this.pageSize = pageSize;
         this.pageNumber = pageNumber;
         this.type = FacetType.valueOf(type);
         this.exclusionTag = exclusionTag;
+        this.minCount = minCount;
     }
 
     public String getField() {
@@ -55,6 +58,10 @@ public class FacetArg {
         return StringUtils.isEmpty(exclusionTag) ? field : String.format("{!ex=%s}%s", exclusionTag, field);
     }
 
+    public int getMinCount() {
+        return minCount;
+    }
+
     @SuppressWarnings("unchecked")
     public static FacetArg of(Object input) {
         Map<String, Object> facet = (Map<String, Object>) input;
@@ -64,16 +71,18 @@ public class FacetArg {
         int pageNumber = (int) facet.get("pageNumber");
         String type = (String) facet.get("type");
         String exclusionTag = facet.containsKey("exclusionTag") ? (String) facet.get("exclusionTag") : StringUtils.EMPTY;
-        return new FacetArg(field, sort, pageSize, pageNumber, type, exclusionTag);
+        int minCount = (int) facet.get("minCount");
+        return new FacetArg(field, sort, pageSize, pageNumber, type, exclusionTag, minCount);
     }
 
-    public static FacetArg of(String field, Optional<String> sort, Optional<String> pageSize, Optional<String> pageNumber, Optional<String> type, Optional<String> exclusionTag) {
+    public static FacetArg of(String field, Optional<String> sort, Optional<String> pageSize, Optional<String> pageNumber, Optional<String> type, Optional<String> exclusionTag, Optional<String> minCount) {
         String sortParam = sort.isPresent() ? sort.get() : "COUNT,DESC";
         int pageSizeParam = pageSize.isPresent() ? Integer.valueOf(pageSize.get()) : 10;
         int pageNumberParam = pageNumber.isPresent() ? Integer.valueOf(pageNumber.get()) : 1;
         String typeParam = type.isPresent() ? type.get() : "STRING";
         String exclusionTagParam = exclusionTag.isPresent() ? exclusionTag.get() : StringUtils.EMPTY;
-        return new FacetArg(field, sortParam, pageSizeParam, pageNumberParam, typeParam, exclusionTagParam);
+        int minCountParam = minCount.isPresent() ? Integer.valueOf(minCount.get()) : 1;
+        return new FacetArg(field, sortParam, pageSizeParam, pageNumberParam, typeParam, exclusionTagParam, minCountParam);
     }
 
 }

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/impl/IndividualRepoImpl.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/model/repo/impl/IndividualRepoImpl.java
@@ -141,6 +141,7 @@ public class IndividualRepoImpl implements SolrDocumentRepoCustom<Individual> {
         facets.forEach(facet -> {
             FieldWithFacetParameters fieldWithFacetParameters = new FieldWithFacetParameters(facet.getCommand());
             // NOTE: other possible; method, minCount, missing, and prefix
+            facetOptions.setFacetMinCount(facet.getMinCount());
             facetOptions.addFacetOnField(fieldWithFacetParameters);
         });
 

--- a/src/main/java/edu/tamu/scholars/middleware/discovery/utility/ArgumentUtility.java
+++ b/src/main/java/edu/tamu/scholars/middleware/discovery/utility/ArgumentUtility.java
@@ -39,6 +39,7 @@ public class ArgumentUtility {
     private final static String FACET_PAGE_NUMBER_FORMAT = "%s.pageNumber";
     private final static String FACET_TYPE_FORMAT = "%s.type";
     private final static String FACET_EXCLUDE_TAG_FORMAT = "%s.exclusionTag";
+    private final static String FACET_MIN_COUNT_FORMAT = "%s.minCount";
 
     private final static String FILTER_VALUE_FORMAT = "%s.filter";
     private final static String FILTER_OPKEY_FORMAT = "%s.opKey";
@@ -86,8 +87,14 @@ public class ArgumentUtility {
                 .map(request::getParameterValues)
                 .map(Arrays::asList)
                 .flatMap(list -> list.stream())
-                .findAny();               
-            return FacetArg.of(field, sort, pageSize, pageNumber, type, exclusionTag);
+                .findAny();  
+            Optional<String> minCount = perameterNames.stream()
+                .filter(paramName -> paramName.equals(String.format(FACET_MIN_COUNT_FORMAT, field)))
+                .map(request::getParameterValues)
+                .map(Arrays::asList)
+                .flatMap(list -> list.stream())
+                .findAny();                             
+            return FacetArg.of(field, sort, pageSize, pageNumber, type, exclusionTag, minCount);
         }).collect(Collectors.toList());
         // @formatter:on
     }

--- a/src/main/java/edu/tamu/scholars/middleware/graphql/config/GraphQLConfig.java
+++ b/src/main/java/edu/tamu/scholars/middleware/graphql/config/GraphQLConfig.java
@@ -212,6 +212,7 @@ public class GraphQLConfig {
                 fields.add(new InputField("pageNumber", "Facet page number", new TypedElement(GenericTypeReflector.annotate(int.class)), GenericTypeReflector.annotate(int.class), 1));
                 fields.add(new InputField("type", "Facet type", new TypedElement(GenericTypeReflector.annotate(FacetType.class)), GenericTypeReflector.annotate(FacetType.class), FacetType.STRING));
                 fields.add(new InputField("exclusionTag", "Tag (in conjunction with Filter)", new TypedElement(GenericTypeReflector.annotate(String.class)), GenericTypeReflector.annotate(String.class), null));
+                fields.add(new InputField("minCount", "Facet mincount", new TypedElement(GenericTypeReflector.annotate(int.class)), GenericTypeReflector.annotate(int.class), 1));
                 return fields;
             }
 

--- a/src/test/java/edu/tamu/scholars/middleware/discovery/argument/FacetArgTest.java
+++ b/src/test/java/edu/tamu/scholars/middleware/discovery/argument/FacetArgTest.java
@@ -20,7 +20,7 @@ public class FacetArgTest {
 
     @Test
     public void testDefaultConstructor() {
-        FacetArg facetArg = new FacetArg("class", "COUNT,DESC", 10, 1, "STRING", "CLAZZ");
+        FacetArg facetArg = new FacetArg("class", "COUNT,DESC", 10, 1, "STRING", "CLAZZ", 1);
         assertNotNull(facetArg);
         assertEquals("class", facetArg.getField());
         assertEquals(FacetSort.COUNT, facetArg.getSort().getProperty());
@@ -29,6 +29,7 @@ public class FacetArgTest {
         assertEquals(1, facetArg.getPageNumber());
         assertEquals(FacetType.STRING, facetArg.getType());
         assertEquals("{!ex=CLAZZ}class", facetArg.getCommand());
+        assertEquals(1, facetArg.getMinCount());
     }
 
     @Test
@@ -40,6 +41,7 @@ public class FacetArgTest {
         params.put("pageNumber", 1);
         params.put("type", "STRING");
         params.put("exclusionTag", "CLAZZ");
+        params.put("minCount", 1);
         FacetArg facetArg = FacetArg.of(params);
         assertNotNull(facetArg);
         assertEquals("class", facetArg.getField());
@@ -49,6 +51,7 @@ public class FacetArgTest {
         assertEquals(1, facetArg.getPageNumber());
         assertEquals(FacetType.STRING, facetArg.getType());
         assertEquals("{!ex=CLAZZ}class", facetArg.getCommand());
+        assertEquals(1, facetArg.getMinCount());
     }
 
     @Test
@@ -58,7 +61,8 @@ public class FacetArgTest {
         Optional<String> pageNumber = Optional.of("1");
         Optional<String> type = Optional.of("STRING");
         Optional<String> exclusionTag = Optional.of("CLAZZ");
-        FacetArg facetArg = FacetArg.of("class", sort, pageSize, pageNumber, type, exclusionTag);
+        Optional<String> minCount = Optional.of("1");
+        FacetArg facetArg = FacetArg.of("class", sort, pageSize, pageNumber, type, exclusionTag, minCount);
         assertNotNull(facetArg);
         assertEquals("class", facetArg.getField());
         assertEquals(FacetSort.COUNT, facetArg.getSort().getProperty());
@@ -67,6 +71,7 @@ public class FacetArgTest {
         assertEquals(1, facetArg.getPageNumber());
         assertEquals(FacetType.STRING, facetArg.getType());
         assertEquals("{!ex=CLAZZ}class", facetArg.getCommand());
+        assertEquals(1, facetArg.getMinCount());
     }
 
 }


### PR DESCRIPTION
We have a use case of showing facets with 0 counts - this should allow that per facet (or other minCounts) but still default to current solr conf/params.json value of 1